### PR TITLE
[MERGE] block-inaccessible-environment into development

### DIFF
--- a/Ravel-Creators/Assets/RavelCreator/Resources/Config/NetConfig.asset
+++ b/Ravel-Creators/Assets/RavelCreator/Resources/Config/NetConfig.asset
@@ -15,4 +15,4 @@ MonoBehaviour:
   reconnectOnDisconnect: 1
   reconnectDuration: 1
   maxReconnectTries: 5
-  _mode: 0
+  _mode: 3

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Creator/Scene/SceneConfiguration.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Creator/Scene/SceneConfiguration.cs
@@ -15,6 +15,28 @@ public class SceneConfiguration : MonoBehaviour
     public bool teleportEnabled = true;
     
 #if UNITY_EDITOR
+
+    public void OnValidate() {
+        SceneConfiguration[] configs = FindObjectsOfType<SceneConfiguration>();
+
+        if (configs.Length > 1 && EditorUtility.DisplayDialog("Double config",
+                "There is already a scene configuration in the scene. No more than one config is allowed per scene!",
+                "ok")) {
+
+            for (int i = 0; i < configs.Length; i++) {
+                if (configs[i] != this) {
+                    EditorGUIUtility.PingObject(configs[i].gameObject);
+                }
+            }
+
+            Debug.LogError(
+                "There is already a scene configuration in the scene. No more than one config is allowed per scene!");
+
+            //destroy component when allowed to. 
+            EditorApplication.delayCall += () => { DestroyImmediate(this); };
+        }
+    }
+
     public static Action environmentUpdated;
     
     [CustomEditor(typeof(SceneConfiguration))]

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/Assetbundles/BundleBuilder.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/Assetbundles/BundleBuilder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Base.Ravel.BackendData.DynamicContent;
+using Base.Ravel.Config;
 using Base.Ravel.Creator.Components;
 using Base.Ravel.Networking;
 using Unity.EditorCoroutines.Editor;
@@ -65,6 +66,7 @@ public static class BundleBuilder
 		//See if there is an active scene configuration in the scene, otherwise cancel the build.
 		//Missing config errors are shown to the user.
 		if (!TryGetConfig(out SceneConfiguration config)) {
+			Debug.LogWarning("Could not find scene configuration component! Cancelling build.");
 			yield break;
 		}
 
@@ -75,6 +77,16 @@ public static class BundleBuilder
 				"Ok");
 
 			Selection.activeObject = config;
+			yield break;
+		}
+
+		if (config.environmentSO.environment.mode != NetworkConfig.AppMode.Unknown &&
+		    config.environmentSO.environment.mode != AppConfig.Networking.Mode) {
+			EditorUtility.DisplayDialog("Appmode mismatch!",
+				$"You are trying to build an {config.environmentSO.environment.mode}, but the currently selected mode" +
+				$"is {AppConfig.Networking.Mode}. Cancelling build.",
+				"Ok");
+			
 			yield break;
 		}
 		

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/CreateEnvironmentWindow.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/CreateEnvironmentWindow.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Base.Ravel.Config;
 using Base.Ravel.Networking;
 using MathBuddy.Strings;
 using UnityEditor;
@@ -95,6 +96,7 @@ public class CreateEnvironmentWindow : EditorWindow
 		//Remove path before assets (AssetDatabase tools use relative path).
 		path = path.Substring(Application.dataPath.Length - 6);
 
+		_environment.mode = AppConfig.Networking.Mode;
 		CreatorRequest req = CreatorRequest.CreateEnvironment(RavelEditor.User.userUUID, _environment);
 		EditorWebRequests.SendWebRequest(req, (res) => OnCreateResponse(res, path), this);
 	}

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/CreateEnvironmentWindow.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/CreateEnvironmentWindow.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Base.Ravel.Config;
 using Base.Ravel.Networking;
 using MathBuddy.Strings;

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/RavelToolbar.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/RavelToolbar.cs
@@ -115,7 +115,7 @@ public class RavelToolbar
 
         //Backend mode that is used to preview on, only accessible for dev users.
         GUI.enabled = RavelEditor.DevUser || !RavelEditor.LoggedIn;
-        bool curMode = AppConfig.Networking.Mode == NetworkConfig.AppMode.Live;
+        bool curMode = AppConfig.Networking.Mode == NetworkConfig.AppMode.App;
         //user picks between app and live
         bool pickedMode = EditorGUILayout.Popup("", curMode ? 0 : 1, new[] { "App", "Dev" }, 
             GUILayout.Width(RavelEditorStying.GUI_SPACING_DECI)) == 0;
@@ -134,7 +134,7 @@ public class RavelToolbar
             
             CreatorWindow.OpenAccount();
             
-            AppConfig.Networking.Mode = (pickedMode) ? NetworkConfig.AppMode.Live : NetworkConfig.AppMode.Development;
+            AppConfig.Networking.Mode = (pickedMode) ? NetworkConfig.AppMode.App : NetworkConfig.AppMode.Development;
             
             EditorUtility.SetDirty(AppConfig.Networking);
             AssetDatabase.SaveAssets();

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/States/EnvironmentState.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/States/EnvironmentState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Base.Ravel.Config;
 using Base.Ravel.Networking;
 using MathBuddy.Strings;
 using Unity.EditorCoroutines.Editor;
@@ -318,6 +319,10 @@ public class EnvironmentState : CreatorWindowState
             res.DataString = EnvironmentExtensions.RenameStringFromBackend(res.DataString);
             
             if (res.TryGetCollection(out ProxyCollection<Environment> environments)) {
+                for (int i = 0; i < environments.Length; i++) {
+                    environments[i].mode = AppConfig.Networking.Mode;
+                }
+                
                 _environments = environments.Array;
                 _names = _environments.GetNames();
 

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/RavelEditor.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/RavelEditor.cs
@@ -104,8 +104,8 @@ public static class RavelEditor
             }
         }
         
-        if (!DevUser && AppConfig.Networking.Mode != NetworkConfig.AppMode.Live) {
-            AppConfig.Networking.Mode = NetworkConfig.AppMode.Live;
+        if (!DevUser && AppConfig.Networking.Mode != NetworkConfig.AppMode.App) {
+            AppConfig.Networking.Mode = NetworkConfig.AppMode.App;
         }
     }
 

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Environment/Editor/EnvironmentSOEditor.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Environment/Editor/EnvironmentSOEditor.cs
@@ -43,18 +43,6 @@ public class EnvironmentSOEditor : Editor
 
     public override void OnInspectorGUI() {
         _instance = (EnvironmentSO)target;
-
-        if (_instance.environment.mode != AppConfig.Networking.Mode) {
-            EditorGUILayout.HelpBox($"Environment does not use the same appmode as is currently selected: {_instance.environment.mode}", MessageType.Warning);
-            GUI.enabled = false;
-        } else if (_instance.environment.mode == NetworkConfig.AppMode.Unknown) {
-            EditorGUILayout.HelpBox($"Environment mode not set, please refresh the environment.", MessageType.Warning);
-            GUI.enabled = RavelEditor.LoggedIn;
-        }
-        else {
-            GUI.enabled = RavelEditor.LoggedIn;
-        }
-        
         
         //draw banner image
         if (_instance.environment.preview == null) {
@@ -85,6 +73,18 @@ public class EnvironmentSOEditor : Editor
         }
 
         GUITitle();
+        
+        //Disable when there is a mode mismatch
+        if (_instance.environment.mode != AppConfig.Networking.Mode) {
+            EditorGUILayout.HelpBox($"Environment ({_instance.environment.mode}) does not use the same appmode as is currently selected ({AppConfig.Networking.Mode}).", MessageType.Warning);
+            GUI.enabled = false;
+        } else if (_instance.environment.mode == NetworkConfig.AppMode.Unknown) {
+            EditorGUILayout.HelpBox($"Environment mode not set, please refresh the environment.", MessageType.Warning);
+            GUI.enabled = RavelEditor.LoggedIn;
+        }
+        else {
+            GUI.enabled = RavelEditor.LoggedIn;
+        }
 
         //environment download error handling
         if (!string.IsNullOrEmpty(networkError)) {

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Environment/Editor/EnvironmentSOEditor.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Environment/Editor/EnvironmentSOEditor.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR
+using Base.Ravel.Config;
 using Base.Ravel.Networking;
 using UnityEditor;
 using UnityEngine;
@@ -33,12 +34,27 @@ public class EnvironmentSOEditor : Editor
     /// </summary>
     private void OnEnable() {
         if (_instance != null) {
-            RefreshEnvironment();
+            if (_instance.environment.mode == NetworkConfig.AppMode.Unknown ||
+                _instance.environment.mode == AppConfig.Networking.Mode) {
+                RefreshEnvironment();
+            }
         }
     }
 
     public override void OnInspectorGUI() {
         _instance = (EnvironmentSO)target;
+
+        if (_instance.environment.mode != AppConfig.Networking.Mode) {
+            EditorGUILayout.HelpBox($"Environment does not use the same appmode as is currently selected: {_instance.environment.mode}", MessageType.Warning);
+            GUI.enabled = false;
+        } else if (_instance.environment.mode == NetworkConfig.AppMode.Unknown) {
+            EditorGUILayout.HelpBox($"Environment mode not set, please refresh the environment.", MessageType.Warning);
+            GUI.enabled = RavelEditor.LoggedIn;
+        }
+        else {
+            GUI.enabled = RavelEditor.LoggedIn;
+        }
+        
         
         //draw banner image
         if (_instance.environment.preview == null) {
@@ -185,11 +201,11 @@ public class EnvironmentSOEditor : Editor
     private void GUIDataUrls() {
         _instance.environment.metadataPreviewImage.TryGetUrl(_size, out string url);
         GUIDrawCopySaveUrl("Image", url, $"IMG_{_instance.environment.name}_{_size.ToString().Substring(1)}", "jpg", 
-            !_uploadingFile);
+            (!_uploadingFile && GUI.enabled));
 
         url = _instance.environment.metadataAssetBundle.assetBundleUrl;
         GUIDrawCopySaveUrl( "Bundle", url, $"BUN_{_instance.environment.name}", "", 
-            !_uploadingFile);
+            (!_uploadingFile && GUI.enabled));
     }
     
     private void GUIDrawCopySaveUrl(string label, string url, string fileName, string extension, bool enabled) {
@@ -397,6 +413,8 @@ public class EnvironmentSOEditor : Editor
             res.DataString = EnvironmentExtensions.RenameStringFromBackend(res.DataString);
 
             if (res.TryGetData(out Environment env)) {
+                env.mode = AppConfig.Networking.Mode;
+                
                 _instance.environment = env;
             }
 

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Environment/Environment.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Environment/Environment.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Base.Ravel.Config;
 using Base.Ravel.CustomAttributes;
 using Base.Ravel.Users;
 using UnityEngine;
@@ -20,6 +21,10 @@ public class Environment
     public string shortSummary;
     [ReadOnly]
     public string longSummary;
+
+    //track whether it is a development or live environment.
+    [ReadOnly]
+    public NetworkConfig.AppMode mode = NetworkConfig.AppMode.Unknown;
     
     //container class for all size image urls.
     [HideInInspector]

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Ravel/Configuration/NetworkConfig.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Ravel/Configuration/NetworkConfig.cs
@@ -192,6 +192,7 @@ namespace Base.Ravel.Config
 
         public enum AppMode
         {
+            Unknown = -1,
             Development = 0,
             Test = 1,
             Live = 2,

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Ravel/Configuration/NetworkConfig.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Ravel/Configuration/NetworkConfig.cs
@@ -74,7 +74,7 @@ namespace Base.Ravel.Config
                     case AppMode.Test:
                         url = "https://test.ravel.systems/";
                         break;
-                    case AppMode.Live:
+                    case AppMode.App:
                         url = "https://live.ravel.systems/";
                         break;
                     case AppMode.LocalHost:
@@ -100,7 +100,7 @@ namespace Base.Ravel.Config
                 case AppMode.Test:
                     url = "https://demo.ravel.world/";
                     break;
-                case AppMode.Live:
+                case AppMode.App:
                     url = "https://app.ravel.world/";
                     break;
                 case AppMode.LocalHost:
@@ -130,7 +130,7 @@ namespace Base.Ravel.Config
                 case AppMode.Test:
                     id = "41149b28-2061-4424-9d2b-0d392ebc8027";
                     break;
-                case AppMode.Live:
+                case AppMode.App:
                     id = "e2bdfa09-1a97-41ab-acbf-a33e10c96a30";
                     break;
                 case AppMode.PersistentSample:
@@ -158,7 +158,7 @@ namespace Base.Ravel.Config
             switch (m) {
                 case AppMode.Development:
                 case AppMode.Test:
-                case AppMode.Live:
+                case AppMode.App:
                 case AppMode.PersistentSample:
                     id = "b5ef7fb8a6004bbab48d15fe4e6b13fd";
                     break;
@@ -181,12 +181,7 @@ namespace Base.Ravel.Config
             if (!cfg) {
                 throw new FileNotFoundException($"No network config found!");
             }
-
-            //TODO: live when no dev build
-            /*
-    #if !UNITY_EDITOR && !DEVELOPMENT_BUILD
-            cfg._mode = NetworkConfig.AppMode.Live;
-    #endif*/
+            
             return cfg;
         }
 
@@ -195,7 +190,7 @@ namespace Base.Ravel.Config
             Unknown = -1,
             Development = 0,
             Test = 1,
-            Live = 2,
+            App = 2, //live
             PersistentSample = 3,
             LocalHost = 4,
         }

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Ravel/Configuration/NetworkConfig.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Ravel/Configuration/NetworkConfig.cs
@@ -67,12 +67,8 @@ namespace Base.Ravel.Config
             }
             else {
                 switch (mode) {
-                    case AppMode.PersistentSample:
                     case AppMode.Development:
                         url = "https://dev.ravel.systems/";
-                        break;
-                    case AppMode.Test:
-                        url = "https://test.ravel.systems/";
                         break;
                     case AppMode.App:
                         url = "https://live.ravel.systems/";
@@ -81,7 +77,8 @@ namespace Base.Ravel.Config
                         url = "http://localhost:8080/";
                         break;
                     default:
-                        throw new MissingFieldException($"No baseurl (Dataservices) for appMode {mode} found!");
+                        Debug.LogError($"Missing base backend url ({mode}), using development");
+                        return GetBaseUrl(AppMode.Development);
                 }
             }
             
@@ -93,12 +90,8 @@ namespace Base.Ravel.Config
         private string GetSiteUrl(AppMode mode) {
             string url;
             switch (mode) {
-                case AppMode.PersistentSample:
                 case AppMode.Development:
                     url = "https://dev.ravel.world/";
-                    break;
-                case AppMode.Test:
-                    url = "https://demo.ravel.world/";
                     break;
                 case AppMode.App:
                     url = "https://app.ravel.world/";
@@ -107,7 +100,8 @@ namespace Base.Ravel.Config
                     url = "http://localhost:8080/";
                     break;
                 default:
-                    throw new MissingFieldException($"No baseurl (Dataservices) for appMode {mode} found!");
+                    Debug.LogError($"Missing site url ({mode}), using development");
+                    return GetSiteUrl(AppMode.Development);
             }
             return url;
         }
@@ -118,26 +112,21 @@ namespace Base.Ravel.Config
 
         //realtimeIds
         // there is only a development (that is also test) app id and a live one
-        //dev:  41149b28-2061-4424-9d2b-0d392ebc8027
-        //test: 41149b28-2061-4424-9d2b-0d392ebc8027
         //live: e2bdfa09-1a97-41ab-acbf-a33e10c96a30
-        //peristentRoomSample: df17aba7-0290-4273-bed4-45a142d93827
+        //dev/persistentRoomSample: df17aba7-0290-4273-bed4-45a142d93827
         private string GetRealtimeId(AppMode m, bool debugValue = false)
         {
             string id;
             switch (m) {
-                case AppMode.Development:
-                case AppMode.Test:
-                    id = "41149b28-2061-4424-9d2b-0d392ebc8027";
-                    break;
                 case AppMode.App:
                     id = "e2bdfa09-1a97-41ab-acbf-a33e10c96a30";
                     break;
-                case AppMode.PersistentSample:
+                case AppMode.Development:
                     id = "93f34f51-bb3f-4ed4-9431-5f26d135efe4"; //"df17aba7-0290-4273-bed4-45a142d93827";
                     break;
                 default:
-                    throw new MissingFieldException($"No ids for appMode {m} found!");
+                    Debug.LogError($"Missing appmode ({m}), using development");
+                    return GetRealtimeId(AppMode.Development);
             }
             
             //TODO: move debug in networker class, not here
@@ -151,24 +140,10 @@ namespace Base.Ravel.Config
 #region AgoraIds
         //agora ids
         // there is only a development (that is also test) app id and a live one
-        //test version jasper:  8cf3286b37474c13af969ce398ede20c
+        //test version:  8cf3286b37474c13af969ce398ede20c
         private string GetAgoraId(AppMode m, bool debugValue = false)
         {
-            string id;
-            switch (m) {
-                case AppMode.Development:
-                case AppMode.Test:
-                case AppMode.App:
-                case AppMode.PersistentSample:
-                    id = "b5ef7fb8a6004bbab48d15fe4e6b13fd";
-                    break;
-                default:
-                    throw new MissingFieldException($"No agora ids for appMode {m} found!");
-            }
-            
-            if (debugValue)
-                Debug.Log($"Using {m} agora id ({id})");
-            return id;
+            return "b5ef7fb8a6004bbab48d15fe4e6b13fd";;
         }
 #endregion
 
@@ -184,14 +159,13 @@ namespace Base.Ravel.Config
             
             return cfg;
         }
-
+        
+        //numbering is weird, but required for Ruben backed, will be fixed in phoenix backend.
         public enum AppMode
         {
             Unknown = -1,
-            Development = 0,
-            Test = 1,
-            App = 2, //live
-            PersistentSample = 3,
+            App = 2,
+            Development = 3,
             LocalHost = 4,
         }
         


### PR DESCRIPTION
https://github.com/XRBASE/Ravel-Unity-02/pull/331

- [ ] dev environments are blocked (except for refresh) when running in app mode (and the other way around).
- [ ] when building an environment in the wrong mode, the application shows a pop-up and cancels the build.