### PR TITLE
[MERGE] fix/wrong-folder-catching into development.

### DIFF
--- a/Ravel-Creators/Assets/RavelCreator/Resources/Config/RavelEditorSettings.asset
+++ b/Ravel-Creators/Assets/RavelCreator/Resources/Config/RavelEditorSettings.asset
@@ -36,5 +36,5 @@ MonoBehaviour:
       guid: cf727050-89ac-45e6-98ff-afdb0039150e
       vMajor: 0
       vMinor: 0
-  _filePath: C:\Users\Lotte\Documents\01-Werk\Base\01-Ravel\Unity\Ravel-Creators-00\Ravel-Creators\Assets\RavelCreator\Examples\Scenes
-  _bundlePath: C:/Users/Lotte/Documents/01-Werk/Base/01-Ravel/Unity/Ravel-Creators-00/Ravel-Creators/Assets/StreamingAssets/
+  _filePath: /
+  _bundlePath: /StreamingAssets

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/Config/RavelCreatorSettings.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/Config/RavelCreatorSettings.cs
@@ -75,8 +75,10 @@ public partial class RavelCreatorSettings : ScriptableObject
 				path = Path.GetDirectoryName(path);
 			}
 
-			if (_filePath != path) {
-				_filePath = path;
+			if (path == Application.dataPath) {
+				_filePath = "/";
+			} else if (_filePath != path) {
+				_filePath = "/" + Path.GetRelativePath(Application.dataPath, path);
 				EditorUtility.SetDirty(this);
 			}
 		}
@@ -91,8 +93,10 @@ public partial class RavelCreatorSettings : ScriptableObject
 				path = Path.GetDirectoryName(path);
 			}
 
-			if (_bundlePath != path) {
-				_bundlePath = path;
+			if (path == Application.dataPath) {
+				_bundlePath = "/";
+			} else if (_bundlePath != path) {
+				_bundlePath = "/" + Path.GetRelativePath(Application.dataPath, path);
 				EditorUtility.SetDirty(this);
 			}
 		}
@@ -102,18 +106,18 @@ public partial class RavelCreatorSettings : ScriptableObject
 	}
 
 	public string GetFilePath() {
-		if (string.IsNullOrEmpty(_filePath)) {
-			_filePath = Application.dataPath + DEFAULT_FILE_PATH;
+		if (string.IsNullOrEmpty(_filePath) || !IsPathInProject(Application.dataPath + _filePath)) {
+			_filePath = DEFAULT_FILE_PATH;
 		}
 
-		return _filePath;
+		return Application.dataPath + _filePath;
 	}
 
 	public string GetBundlePath() {
-		if (string.IsNullOrEmpty(_bundlePath)) {
-			_bundlePath = Application.dataPath + DEFAULT_BUNDLE_PATH;
+		if (string.IsNullOrEmpty(_bundlePath) || !IsPathInProject(Application.dataPath + _bundlePath)) {
+			_bundlePath = DEFAULT_BUNDLE_PATH;
 		}
 
-		return _bundlePath;
+		return Application.dataPath + _bundlePath;
 	}
 }

--- a/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/Config/RavelCreatorSettingsEditor.cs
+++ b/Ravel-Creators/Assets/RavelCreator/Scripts/Editor/CreatorTools/Config/RavelCreatorSettingsEditor.cs
@@ -20,11 +20,11 @@ public partial class RavelCreatorSettings
 		public override void OnInspectorGUI() {
 			DrawDefaultInspector();
 
-			GUIDrawFolderAndSetBtn(_instance._filePath, _instance.SetFilePath,
+			GUIDrawFolderAndSetBtn(_instance.GetFilePath(), _instance.SetFilePath,
 				new GUIContent("File path", "(Last used) Path that is opened when accessing files. " +
 				                            "Should be a folder within the asset folder of this project.\n" +
 				                            $"{_instance._filePath}"));
-			GUIDrawFolderAndSetBtn(_instance._bundlePath, _instance.SetBundlePath,
+			GUIDrawFolderAndSetBtn(_instance.GetBundlePath(), _instance.SetBundlePath,
 				new GUIContent("Bundle path", "The location at which assetbundles are saved." +
 				                              "Should be a folder within the asset folder of this project.\n" +
 				                              $"{_instance._bundlePath}"));
@@ -32,7 +32,7 @@ public partial class RavelCreatorSettings
 
 		private void GUIDrawFolderAndSetBtn(string value, Action<string> setValueAction, GUIContent content) {
 			EditorGUILayout.BeginHorizontal();
-			
+
 			string data = EditorGUILayout.TextField(content, value);
 			if (!Directory.Exists(data)) {
 				Debug.LogWarning("Filled in path is invalid.");


### PR DESCRIPTION
- [ ] when a path of a different machine is used in the settings (or a wrong path) the path is reset.
- [ ] the file and bundle paths are saved as relative paths, so that a path that was saved on a different machine still works on another machine.